### PR TITLE
refactor: rename project from BoardWex to MyBoard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Personal Miro - Online Whiteboard & Drawing Tool
+# MyBoard - Personal Whiteboard & Drawing Tool
 
 **A single-user Miro clone whiteboard app with local state management using Zustand and PostgreSQL persistence - no real-time collaboration, no Liveblocks/Convex dependencies, just pure personal drawing and creativity.**
 
-Originally forked from [aftabrehan/board-wex](https://github.com/aftabrehan/board-wex), this project has been completely refactored to remove expensive SaaS dependencies (Liveblocks & Convex) and transformed into a self-hostable personal whiteboard solution.
+Originally forked from [aftabrehan/board-wex](https://github.com/aftabrehan/board-wex), this project has been completely refactored and renamed to MyBoard. It removes expensive SaaS dependencies (Liveblocks & Convex) and has been transformed into a self-hostable personal whiteboard solution.
 
 ## 🎯 Why This Fork?
 
@@ -69,8 +69,8 @@ This fork removes these dependencies to create a **completely free and self-host
 ### 1. Clone the repository
 
 ```bash
-git clone https://github.com/ttpss930141011/personal-miro.git
-cd personal-miro
+git clone https://github.com/ttpss930141011/myboard.git
+cd myboard
 ```
 
 ### 2. Install dependencies
@@ -87,7 +87,7 @@ Create a `.env` file in the root directory:
 
 ```env
 # Database
-DATABASE_URL="postgresql://user:password@localhost:5432/personal_miro"
+DATABASE_URL="postgresql://user:password@localhost:5432/myboard"
 
 # Auth.js Configuration
 NEXTAUTH_URL=http://localhost:3000
@@ -179,7 +179,7 @@ For production deployment, update the redirect URIs to your production domain:
 ## 🏗️ Project Structure
 
 ```
-personal-miro/
+myboard/
 ├── app/                    # Next.js app router pages
 │   ├── (auth)/            # Authentication pages
 │   ├── (dashboard)/       # Main application pages

--- a/app/(dashboard)/_components/org-sidebar.tsx
+++ b/app/(dashboard)/_components/org-sidebar.tsx
@@ -23,7 +23,7 @@ export const OrgSidebar = () => {
         <div className="flex items-center gap-x-2">
           <Image src="/logo.svg" alt="Logo" height={28} width={28} />
           <span className={cn('font-semibold text-2xl', font.className)}>
-            BoardWex
+            MyBoard
           </span>
         </div>
       </Link>

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -4,8 +4,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Metadata } from "next"
 
 export const metadata: Metadata = {
-  title: "Sign In - BoardWex",
-  description: "Sign in to your BoardWex account",
+  title: "Sign In - MyBoard",
+  description: "Sign in to your MyBoard account",
 }
 
 export default function SignInPage() {

--- a/app/board/[boardId]/_components/info.tsx
+++ b/app/board/[boardId]/_components/info.tsx
@@ -39,7 +39,7 @@ export const Info = ({ boardId }: InfoProps) => {
                 font.className
               )}
             >
-              BoardWex
+              MyBoard
             </span>
           </Link>
         </Button>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,8 +12,8 @@ import './globals.css'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'BoardWex - Collaborate while drawing notes',
-  description: 'Collaborate while drawing notes.',
+  title: 'MyBoard - Personal whiteboard for drawing and notes',
+  description: 'Your personal whiteboard for drawing, notes, and creative thinking.',
 }
 
 export default function RootLayout({

--- a/docs/AUTHJS_SETUP_GUIDE.md
+++ b/docs/AUTHJS_SETUP_GUIDE.md
@@ -1,6 +1,6 @@
 # Auth.js Setup Guide
 
-This guide walks you through setting up Auth.js v5 (NextAuth) for the Personal Miro application.
+This guide walks you through setting up Auth.js v5 (NextAuth) for the MyBoard application.
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ Create a `.env` file in your project root with the following variables:
 
 ```env
 # Database (required)
-DATABASE_URL="postgresql://user:password@localhost:5432/personal_miro"
+DATABASE_URL="postgresql://user:password@localhost:5432/myboard"
 
 # Auth.js Configuration (required)
 NEXTAUTH_URL=http://localhost:3000

--- a/docs/CLERK_TO_AUTHJS_MIGRATION.md
+++ b/docs/CLERK_TO_AUTHJS_MIGRATION.md
@@ -1,6 +1,6 @@
 # Clerk to Auth.js Migration Guide
 
-This document details the complete migration from Clerk authentication to Auth.js v5 (NextAuth) in the Personal Miro project.
+This document details the complete migration from Clerk authentication to Auth.js v5 (NextAuth) in the MyBoard project.
 
 ## Migration Overview
 
@@ -179,4 +179,4 @@ However, this migration has been thoroughly tested and is considered stable.
 
 - [Auth.js Documentation](https://authjs.dev/)
 - [Edge Compatibility Guide](https://authjs.dev/guides/edge-compatibility)
-- [PR #6 - Remove Clerk and implement Auth.js v5](https://github.com/ttpss930141011/personal-miro/pull/6)
+- [PR #6 - Remove Clerk and implement Auth.js v5](https://github.com/ttpss930141011/myboard/pull/6)

--- a/docs/NEXTJS_15_UPGRADE.md
+++ b/docs/NEXTJS_15_UPGRADE.md
@@ -1,6 +1,6 @@
 # Next.js 15 Upgrade Guide
 
-This document details the upgrade from Next.js 14.1.1 to Next.js 15.4.2 in the Personal Miro project.
+This document details the upgrade from Next.js 14.1.1 to Next.js 15.4.2 in the MyBoard project.
 
 ## Overview
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# Personal Miro Documentation
+# MyBoard Documentation
 
-Welcome to the documentation for Personal Miro - a single-user whiteboard application forked from BoardWex.
+Welcome to the documentation for MyBoard - a personal single-user whiteboard application.
 
 ## Documentation Structure
 
@@ -20,7 +20,7 @@ Welcome to the documentation for Personal Miro - a single-user whiteboard applic
 ## Quick Links
 
 - [Main README](../README.md) - Project overview and setup
-- [GitHub Repository](https://github.com/ttpss930141011/personal-miro)
+- [GitHub Repository](https://github.com/ttpss930141011/myboard)
 
 ## Key Features
 

--- a/docs/architecture/ARCHITECTURE_CHANGES.md
+++ b/docs/architecture/ARCHITECTURE_CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document outlines the major architectural transformation of BoardWex from a real-time collaborative whiteboard (Miro clone) to a single-user personal whiteboard application. This refactoring removed expensive SaaS dependencies while maintaining all core functionality.
+This document outlines the major architectural transformation from the original BoardWex (a real-time collaborative whiteboard) to MyBoard - a single-user personal whiteboard application. This refactoring removed expensive SaaS dependencies while maintaining all core functionality.
 
 ## Key Changes
 

--- a/docs/architecture/AUTHJS_IMPLEMENTATION_GUIDE.md
+++ b/docs/architecture/AUTHJS_IMPLEMENTATION_GUIDE.md
@@ -1,6 +1,6 @@
-# Auth.js Implementation Guide for Personal Miro
+# Auth.js Implementation Guide for MyBoard
 
-This guide provides step-by-step instructions for implementing Auth.js v5 in the Personal Miro project, replacing Clerk.
+This guide provides step-by-step instructions for implementing Auth.js v5 in the MyBoard project, replacing Clerk.
 
 ## Step 1: Install Dependencies
 
@@ -247,7 +247,7 @@ export default function SignInPage() {
     <div className="min-h-screen flex items-center justify-center">
       <Card className="w-[400px]">
         <CardHeader>
-          <CardTitle>Sign in to Personal Miro</CardTitle>
+          <CardTitle>Sign in to MyBoard</CardTitle>
           <CardDescription>
             Choose your preferred sign-in method
           </CardDescription>

--- a/docs/architecture/CLERK_TO_AUTHJS_MIGRATION.md
+++ b/docs/architecture/CLERK_TO_AUTHJS_MIGRATION.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-This report outlines the comprehensive migration plan from Clerk to Auth.js (NextAuth v5) for the Personal Miro whiteboard application. The migration will remove the paid Clerk dependency while maintaining authentication functionality, simplified for a single-user focused application with read-only sharing capabilities.
+This report outlines the comprehensive migration plan from Clerk to Auth.js (NextAuth v5) for the MyBoard whiteboard application. The migration will remove the paid Clerk dependency while maintaining authentication functionality, simplified for a single-user focused application with read-only sharing capabilities.
 
 ## Current State Analysis
 

--- a/docs/development/CLAUDE.md
+++ b/docs/development/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-BoardWex is a real-time collaborative whiteboard application (Miro clone) built with:
+MyBoard is a personal whiteboard application (Miro clone) built with:
 - **Frontend**: Next.js 14, React 18, TypeScript (strict mode)
 - **Database**: Prisma with PostgreSQL
 - **Auth**: Clerk (with organizations and invites)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "personal-miro",
+  "name": "myboard",
   "version": "0.1.0",
   "description": "A personal online whiteboard and drawing application",
   "private": true,


### PR DESCRIPTION
## Summary
Renamed the project from the legacy "BoardWex" name to "MyBoard" for better branding and consistency.

## Changes Made

### UI Updates
- Updated logo text in sidebar and board header from "BoardWex" to "MyBoard"
- Changed page titles and metadata to use MyBoard

### Package Configuration
- Updated package name from `personal-miro` to `myboard`
- Consistent naming throughout the project

### Documentation Updates
- Updated all references from BoardWex/Personal Miro to MyBoard
- Changed GitHub repository URLs to use myboard
- Updated database name suggestion to `myboard`

## Testing
- ✅ Build successful
- ✅ All components render correctly with new name
- ✅ No broken references found

## Notes
This is purely a cosmetic change - no functionality has been altered. The name "MyBoard" better reflects the personal nature of this whiteboard application.

🤖 Generated with [Claude Code](https://claude.ai/code)